### PR TITLE
Fix: Non-standard ports should be part of $_SERVER['HTTP_HOST']

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -50,6 +50,9 @@ function upal_init() {
 
   $_SERVER['HTTP_HOST'] = $url['host'];
   $_SERVER['SERVER_PORT'] = array_key_exists('port', $url) ? $url['port'] : NULL;
+  if ($_SERVER['SERVER_PORT']) {
+    $_SERVER['HTTP_HOST'] .= ':' . $_SERVER['SERVER_PORT'];
+  }
 
   set_include_path(UPAL_ROOT . PATH_SEPARATOR . get_include_path());
 


### PR DESCRIPTION
- It seems that other ports than 80 are usually part of
  $_SERVER['HTTP_HOST'].
- url() definitely needs this to construct proper URLs.